### PR TITLE
Refactor bbinfo file to be an advanced feature not enabled by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.4.0] - 2024-?
+
+### Changed
+- Refactored and made the BranchInfo file an opt-in feature. For the few fans of this feature, you'll need to manually enable it after the update.
+
+### Fixed
+- Removed BranchInfo file caching to avoid bugs related to non-gbs modifications to the file
+
+
 ## [0.3.0] - 2023-08-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ Git Backup & Sync currently supports the following commands:
 ## Extension Settings
 This extension contributes the following settings:
 
-* `git-backup-sync.branchInfoPath`: Points to the location of the branch info file. This defaults to `.branchinfo`.
-* `git-backup-sync.defaultBackupUpstreamName`: Name of the default upstream name. This defaults to `origin`.
-* `git-backup-sync.defaultAutoBackupBranches`: When creating new backup branches, the new backup branch starts off with `autobackup = defaultAutoBackupBranches`. This defaults to `false`.
-* `git-backup-sync.shouldCommitBranchInfoFile`: When creating a new Backup Branch, do you want to commit the branch info file change. (This is useful for sharing across devices). This defaults to `false`.
 * `git-backup-sync.backupBranchNamePrefix`: The default prefix of the backup branch name. This defaults to `"gbs-backup-"`.
+* `git-backup-sync.defaultAutoBackupBranches`: Whether to auto backup upon detecting changes in VSCode. This defaults to `false`.
+* `git-backup-sync.defaultBackupUpstreamName`: Name of the default upstream name. This defaults to `origin`.
+
+And for more customizations using the "branch info" file, there are the following settings:
+* `git-backup-sync.branchInfo.enable`: Whether to enable the branch info file. Enabling this file allows for more granular customization per branch, at the cost of needing to manage an additional config file. This defaults to `false`.
+* `git-backup-sync.branchInfo.path`: Points to the location of the branch info file. This defaults to `.bbinfo`.
+* `git-backup-sync.branchInfo.shouldCommitBranchInfoFile`: When creating a new Backup Branch, do you want to commit the branch info file change. (This is useful for sharing across devices). This defaults to `false`.
 
 These settings don't need to be shared and can be different across clones, even including `branchInfoPath`. (But if one wants to sync changes across devices, they need to use the same backup branch. )
 
@@ -44,3 +47,7 @@ The code for this extension is available on github at: https://github.com/maxyu1
 
 ## Want to Contribute?
 I have already created a few issues. Feel free to grab one, work on it, and make a pull request. If you have other ideas, feel free to start a thread in discussions.
+
+To setup your dev environment, you need `npm` as well as vscode. After cloning, run `npm install` to setup, and F5 to build and run the extension locally.
+
+And after making your changes, please document a short summary in the `CHANGELOG.md`, following the current format.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-backup-sync",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "git-backup-sync",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "simple-git": "^3.16.1"
       },
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5765,9 +5765,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -46,11 +46,6 @@
       "type": "object",
       "title": "Git Backup & Sync",
       "properties": {
-        "git-backup-sync.branchInfoPath": {
-          "type": "string",
-          "default": ".bbinfo",
-          "description": "Path pointing to the Backup Branch Info file. This file stores backup branch information necessary to the extension. "
-        },
         "git-backup-sync.defaultAutoBackupBranches": {
           "type": "boolean",
           "default": false,
@@ -61,15 +56,25 @@
           "default": "origin",
           "description": "The upstream name we backup to. This defaults to \"origin\""
         },
-        "git-backup-sync.shouldCommitBranchInfoFile": {
-          "type": "boolean",
-          "default": false,
-          "description": "When creating a new Backup Branch, do you want to commit the branch info file change. (This is useful for sharing across devices)"
-        },
         "git-backup-sync.backupBranchNamePrefix": {
           "type": "string",
           "default": "gbs-backup-",
           "description": "The prefix of backup branch name. This defaults to 'gbs-backup-' "
+        },
+        "git-backup-sync.branchInfo.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to enable the branch info file. Enabling this file allows for more granular customization per branch, at the cost of needing to manage an additional config file."
+        },
+        "git-backup-sync.branchInfo.path": {
+          "type": "string",
+          "default": ".bbinfo",
+          "markdownDescription": "**This only is effective when branchInfo file is enabled**. Path pointing to the Backup Branch Info file. "
+        },
+        "git-backup-sync.branchInfo.shouldCommitBranchInfoFile": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "**This only is effective when branchInfo file is enabled**. When creating a new Backup Branch, do you want to commit the branch info file change. (This is useful for sharing across devices)"
         }
       }
     }


### PR DESCRIPTION
As brought up here: https://github.com/maxyu1115/git-backup-sync/issues/25

The branch info file has honestly been a rabbit hole I went down. The original idea was to have a solution solving the use case of having custom backup branch names. "If we don't have a config file, how will the extension know?" This lead to the branch info file, and then in order to make the branch info file work, I kept needing to add more and more jank settings, like `shouldCommitBranchInfoFile`, #20 , #22 , etc. After taking a step back from active development, it became embarrassingly obvious how hard to use and confusing this file was.

Instead, make the default behavior backup any branch `A` to `gbs-backup-A`. This should be enough for 99% of the users. For the remaining 1%, they can still enable the branch info file as an advanced setting.